### PR TITLE
CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 dist
 testRun.js
 src/db
+
+# vim
+.*.swp

--- a/bin/mysql-types-generator
+++ b/bin/mysql-types-generator
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/cli');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "mysql2": "^2.3.3"
       },
+      "bin": {
+        "mysql-types-generator": "bin/mysql-types-generator"
+      },
       "devDependencies": {
         "@types/jest": "^28.1.4",
         "@types/node": "^18.0.3",
@@ -1333,9 +1336,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
+      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -6196,9 +6199,9 @@
       }
     },
     "@types/node": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
+      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "bin/**/*"
   ],
+  "bin": "./bin/mysql-types-generator",
   "scripts": {
     "prep": "npm test && npm run lint && npm run format && npm run build",
     "prepublishOnly": "npm run prep",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,7 +78,6 @@ generateMysqlTypes({
     path: positionals[1]
   },
 
-
   suffix: values.suffix,
 
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,105 @@
+// tslint:disable no-console
+
+// @ts-expect-error This is a very new API, and @types/node doesn't have types
+// for this yet.
+import { parseArgs } from 'node:util';
+import { generateMysqlTypes } from './generateMysqlTypes';
+
+type CliOption = {
+  type: 'string' | 'boolean';
+  short?: string;
+  description?: string;
+  default?: string;
+}
+
+const options: Record<string, CliOption> = {
+
+  host: {
+    type: 'string',
+    short: 'h',
+    description: 'MySQL hostname. (defaults to 127.0.0.1)',
+    default: '127.0.0.1',
+  },
+  port: {
+    type: 'string',
+    short: 'P',
+    description: 'Port (default is 3306)',
+    default: '3306',
+  },
+  user: {
+    type: 'string',
+    short: 'u',
+    description: 'Username (default is the current user)',
+    default: process.env.user, 
+  },
+  password: {
+    type: 'string',
+    short: 'p',
+    description: 'Password',
+    default: '',
+  },
+  suffix: {
+    type: 'string',
+    description: 'When specified, the name of each generated type will end in this name.',
+  },
+  help: {
+    type: 'boolean',
+    description: 'This help message',
+  }
+
+};
+
+const { values, positionals } = parseArgs({
+  options,
+  allowPositionals: true,
+  strict: true,
+});
+
+if (positionals.length !== 2) {
+  help();
+  console.error('This command requires exactly 2 arguments');
+  process.exit(1);
+}
+if (values.help) {
+  help();
+  process.exit(0);
+}
+
+generateMysqlTypes({
+  db: {
+    host: values.host ?? options.host.default,
+    port: +(values.port ?? options.port.default),
+    user: values.user ?? options.user.default,
+    password: values.password ?? options.password.default,
+    database: positionals[0],
+  },
+
+  output: {
+    path: positionals[1]
+  },
+
+
+  suffix: values.suffix,
+
+});
+
+function help() {
+
+  const command = process.argv[0]; 
+
+  // tslint:disable no-console
+  console.info(`mysql-types-generator
+
+Usage:
+  ${command} [mysql databasename] [output file].ts
+  ${command} [mysql databasename] [output directory]
+
+Options:`);
+  for(const [key, option] of Object.entries(options)) {
+    console.info(`
+  --${key}${option.short?' -' + option.short:''}
+      ${option.description}`);
+  }
+
+}
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,7 +85,7 @@ generateMysqlTypes({
 
 function help() {
 
-  const command = process.argv[0]; 
+  const command = 'npx mysql-types-generator';
 
   // tslint:disable no-console
   console.info(`mysql-types-generator


### PR DESCRIPTION
Here it is!

A few notes:

* This uses a brand-spanking new Node API: parseOpts. This means you need Node 18 to use this. If you don't like this, I can find a library or polyfill. It doesn't take a lot to rework this with a different lib so LMK if this is important to you.
* Open to lots of feedback including stylistic. This is your library, and happy to keep making changes until you like it.
* I just added the basics, not yet `ignoreTables` and especially `overrides` seems a bit challenging.
* All the arguments match the argument style of the standard `mysql` command, if there was a match. This is why I made 'database' positional, and chose `-P` for port.

Fixes #2 