### PR TITLE
Simplify writeToFile

### DIFF
--- a/src/writeToFile.ts
+++ b/src/writeToFile.ts
@@ -1,29 +1,20 @@
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 
 import { warningHeader } from './warningHeader';
 
 export const writeToFile = async (filePath: string, text: string) => {
-  const fileStreamOptions: { encoding: 'utf8'; flags?: string } = { encoding: 'utf8' };
 
-  let append = false;
-  if (fs.existsSync(filePath)) {
-    append = true;
-    fileStreamOptions.flags = 'a';
+  if (await fileExists(filePath)) {
+    await fs.appendFile(filePath, text);
+  } else {
+    await fs.writeFile(filePath, warningHeader + text);
   }
 
-  const fileStream = fs.createWriteStream(filePath, fileStreamOptions);
-
-  // add the warning header
-  if (!append) {
-    fileStream.write(warningHeader);
-  }
-
-  // write the text
-  fileStream.write(text);
-
-  // close the file stream
-  await new Promise((resolve, reject) => {
-    fileStream.on('finish', resolve);
-    fileStream.end();
-  });
 };
+
+function fileExists(filePath: string): Promise<boolean> {
+  // For some reason there's no fsPromises.exists :(
+  return fs.stat(filePath)
+    .then(() => true)
+    .catch(() => false);
+}


### PR DESCRIPTION
There's no functional changes here, just switching to fs/promises for slightly leaner code.

The lint part of the build fails, but the linting errors are all fixed in #6 