### PR TITLE
Insert column comments in output.

### DIFF
--- a/src/generateMysqlTypes.ts
+++ b/src/generateMysqlTypes.ts
@@ -83,7 +83,7 @@ export const generateMysqlTypes = async (config: GenerateMysqlTypesConfig) => {
 
     // get the columns
     const [columns] = (await connection.execute(
-      'SELECT column_name, data_type, column_type, is_nullable FROM information_schema.columns WHERE table_schema = ? and table_name = ? ORDER BY ordinal_position ASC',
+      'SELECT column_name, data_type, column_type, is_nullable, column_comment FROM information_schema.columns WHERE table_schema = ? and table_name = ? ORDER BY ordinal_position ASC',
       [config.db.database, table],
     )) as any;
 
@@ -106,9 +106,18 @@ export const generateMysqlTypes = async (config: GenerateMysqlTypesConfig) => {
         );
       }
 
+      let comment = '';
+      if (column.COLUMN_COMMENT) {
+        comment = `
+  /**
+   * ${column.COLUMN_COMMENT}
+   */
+`;
+      }
+
       await writeToFile(
         outputTypeFilePath,
-        `  ${column.COLUMN_NAME}: ${columnDataType}${column.IS_NULLABLE === 'YES' ? ' | null' : ''};\n`,
+        `${comment}  ${column.COLUMN_NAME}: ${columnDataType}${column.IS_NULLABLE === 'YES' ? ' | null' : ''};\n`,
       );
     }
     await writeToFile(outputTypeFilePath, '}\n\n');


### PR DESCRIPTION
MySQL supports comments on columns. This PR turns those comments into Javascript comments.

Sample output from a database I'm testing with (arguably not a great example)

```typescript
export type Principals = {
  id: number;
  identity: string;
  external_id: string;
  nickname: string | null;
  created_at: number;
  active: boolean;

  /**
   * 1 = user, 2 = app
   */
  type: boolean;
  modified_at: number;
}
```