### PR TITLE
MariaDB support.

### DIFF
--- a/src/generateMysqlTypes.ts
+++ b/src/generateMysqlTypes.ts
@@ -172,7 +172,7 @@ async function getTableNames(
     .filter((tableName: string) => !ignoredTables.includes(tableName));
 }
 
-const columnInfoColumns = ['column_name', 'data_type', 'column_type', 'is_nullable', 'column_comment'] as const;
+const columnInfoColumns = ['COLUMN_NAME', 'DATA_TYPE', 'COLUMN_TYPE', 'IS_NULLABLE', 'COLUMN_COMMENT'] as const;
 
 async function getColumnInfo(
   connection: mysql.Connection,


### PR DESCRIPTION
MariaDB and MySQL behave differently in subtle ways. If you call:

```sql
SELECT column_type FROM INFORMATION_SCHEMA.COLUMNS
```

Then MySQL will return you an array with objects that have an uppercase `COLUMN_TYPE` because the actual underlying information_schema uses uppercase for all table and column names.

MariaDB will also return the data, but it changes 'COLUMN_TYPE' to 'column_type'.

So just asking for the data in the correct case ensures that this code works the same in Maria and MySQL.