### PR TITLE
Pr/22

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Most options from the Javascript API are available, run `npx mysql-types-generat
 
 ## Change Log
 
+- `2.0.0`
+  - Changed mapping of `decimal` column to string instead of number
+  - Added `includeTables` option (optional) to specify a list of tables to generate types for
+  - CLI: Added the `ignoreTables` and `includeTables` options
+  - CLI: Output to `STDOUT` if no `--outDir` or `--outFile` option is provided
+  - JS API: Added `stream` option to ouput to a `writeStream`
 - `1.0.8`
   - Bugfixes: node version check, MariaDB support, ES2020 target
 - `1.0.3`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mysql-types-generator",
-  "version": "1.0.8",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mysql-types-generator",
-      "version": "1.0.8",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "mysql2": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql-types-generator",
-  "version": "1.0.8",
+  "version": "2.0.0",
   "description": "Generate Typescript types from a MySQL database",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,14 @@ const options: Record<string, CliOption> = {
     description:
       'When specified, tinyint(1) columns will be treated as boolean. By default they are treated as number.',
   },
+  ignoreTables: {
+    type: 'string',
+    description: 'Comma-separated list of tables to ignore',
+  },
+  includeTables: {
+    type: 'string',
+    description: 'Comma-separated list of tables to include',
+  },
   help: {
     type: 'boolean',
     description: 'This help message',
@@ -94,11 +102,12 @@ if (positionals.length !== 1) {
   process.exit(1);
 }
 
-if (!values.outDir && !values.outFile) {
-  help();
-  console.error('Either --outFile or --outDir must be specified.');
-  process.exit(1);
-}
+// if (!values.outDir && !values.outFile) {
+//   help();
+//   console.error('Either --outFile or --outDir must be specified.');
+//   process.exit(1);
+// }
+
 if (values.outDir && values.outFile) {
   help();
   console.error('The --outDir and --outFile options are mutually exclusive. Choose one!');
@@ -125,11 +134,19 @@ if (values.uri && values.uri.length > 0) {
 generateMysqlTypes({
   db: dbConfig,
 
-  output: values.outFile ? { file: values.outFile } : { dir: values.outDir },
+  output: values.outFile
+    ? { file: values.outFile }
+    : values.outDir
+      ? { dir: values.outDir }
+      : { stream: process.stdout },
 
   suffix: values.suffix,
 
   tinyintIsBoolean: values.tinyintIsBoolean,
+
+  ignoreTables: values.ignoreTables ? values.ignoreTables.split(',') : [],
+
+  includeTables: values.includeTables ? values.includeTables.split(',') : [],
 });
 
 function help() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,8 +137,8 @@ generateMysqlTypes({
   output: values.outFile
     ? { file: values.outFile }
     : values.outDir
-      ? { dir: values.outDir }
-      : { stream: process.stdout },
+    ? { dir: values.outDir }
+    : { stream: process.stdout },
 
   suffix: values.suffix,
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,8 +137,8 @@ generateMysqlTypes({
   output: values.outFile
     ? { file: values.outFile }
     : values.outDir
-    ? { dir: values.outDir }
-    : { stream: process.stdout },
+      ? { dir: values.outDir }
+      : { stream: process.stdout },
 
   suffix: values.suffix,
 

--- a/src/generateMysqlTypes.ts
+++ b/src/generateMysqlTypes.ts
@@ -102,8 +102,8 @@ export const generateMysqlTypes = async (config: GenerateMysqlTypesConfig) => {
       'dir' in config.output
         ? `${config.output.dir}/${typeName}.ts`
         : 'file' in config.output
-        ? config.output.file
-        : config.output.stream;
+          ? config.output.file
+          : config.output.stream;
 
     // start outputting the type
     await output(outputDestination, `export type ${typeName} = {\n`);

--- a/src/generateMysqlTypes.ts
+++ b/src/generateMysqlTypes.ts
@@ -102,8 +102,8 @@ export const generateMysqlTypes = async (config: GenerateMysqlTypesConfig) => {
       'dir' in config.output
         ? `${config.output.dir}/${typeName}.ts`
         : 'file' in config.output
-          ? config.output.file
-          : config.output.stream;
+        ? config.output.file
+        : config.output.stream;
 
     // start outputting the type
     await output(outputDestination, `export type ${typeName} = {\n`);

--- a/src/getColumnDataType.ts
+++ b/src/getColumnDataType.ts
@@ -8,7 +8,6 @@ export const getColumnDataType = (dataType: string | null, columnType: string, t
     case 'smallint':
     case 'mediumint':
     case 'bigint':
-    case 'decimal':
     case 'float':
     case 'double':
     case 'numeric':
@@ -19,6 +18,7 @@ export const getColumnDataType = (dataType: string | null, columnType: string, t
     case 'text':
     case 'mediumtext':
     case 'longtext':
+    case 'decimal':
       return 'string';
 
     case 'date':


### PR DESCRIPTION
For version 2.0.0

- changed decimal mapping to string [#22](https://github.com/coreyarms/mysql-types-generator/issues/22)
- added includeTables option to JS API and CLI [#14](https://github.com/coreyarms/mysql-types-generator/issues/14)
- added ignoreTables option to CLI (was already in JS API)
- added stream output to JS API, and CLI outputs to STDOUT if no output file or dir is provided [#13](https://github.com/coreyarms/mysql-types-generator/issues/13)